### PR TITLE
Make pulls of Monobank API periodical instead of every `/rate` bot command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # Telegram API token
-BOT_TOKEN=
+BOT_TOKEN=your_bot_token
+# PULL_INTERVAL in seconds, must be between 30 and 3600, default is 300 (Optional)
+# PULL_INTERVAL=300

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,10 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -51,15 +55,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Docker image and push to registry
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          # push to registry when merge to main
-          push: ${{ github.ref == 'refs/heads/main' }}
-          no-cache: true
-          tags: ghcr.io/yurnov/xratebot:latest, ghcr.io/yurnov/xratebot:${{ github.sha }}
-
       - name: Build Docker image for development version and push to registry
         uses: docker/build-push-action@v3
         with:
@@ -68,3 +63,15 @@ jobs:
           push: ${{ github.ref == 'refs/heads/development' }}
           no-cache: true
           tags: ghcr.io/yurnov/xratebot:dev
+
+      - name: Build Docker image and push to registry
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          # push to registry when merge to main
+          push: ${{ github.ref == 'refs/heads/main' }}
+          no-cache: true
+          tags: |
+            ghcr.io/yurnov/xratebot:latest
+            ghcr.io/yurnov/xratebot:${{ steps.get_version.outputs.VERSION }}
+            ghcr.io/yurnov/xratebot:${{ github.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish Docker image to GitHub Container Registry
-on: [push]
-
+on:
+  push:
+    branches:
+      - main
+      - development
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -11,10 +14,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+        with:
+          fetch-tags: True
 
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -59,7 +60,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          # push to registry when merge to main
+          # push to registry when merge to development
           push: ${{ github.ref == 'refs/heads/development' }}
           no-cache: true
           tags: ghcr.io/yurnov/xratebot:dev
@@ -73,5 +74,5 @@ jobs:
           no-cache: true
           tags: |
             ghcr.io/yurnov/xratebot:latest
-            ghcr.io/yurnov/xratebot:${{ steps.get_version.outputs.VERSION }}
             ghcr.io/yurnov/xratebot:${{ github.sha }}
+  

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,3 +59,12 @@ jobs:
           push: ${{ github.ref == 'refs/heads/main' }}
           no-cache: true
           tags: ghcr.io/yurnov/xratebot:latest, ghcr.io/yurnov/xratebot:${{ github.sha }}
+
+      - name: Build Docker image for development version and push to registry
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          # push to registry when merge to main
+          push: ${{ github.ref == 'refs/heads/development' }}
+          no-cache: true
+          tags: ghcr.io/yurnov/xratebot:dev

--- a/.github/workflows/update_ver.yml
+++ b/.github/workflows/update_ver.yml
@@ -1,0 +1,18 @@
+name: Bump version
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: True
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: minor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 0.1.2
+
+Instead of individual API call for each `/rate` bot command rates pulled in configurable interval
+
+## 0.1.1
+
+Version with fix of `/start` answer
+
+## 0.1.0 (yanked)
+
+Version yanked due to code error
+
+## [pre-0.1.0](c218c5c43a8d3a3c477740b424e7d8ea53e487cf)
+
+First working version

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.authors="Yuriy Novostavskiy" \
       org.opencontainers.image.license="MIT" \
       org.opencontainers.image.description="A simple bot that sends the current exchange rate of the USD, EUR, and PLN to UAH from Monobank to a Telegram chat"
 
-RUN python -m pip install requests~=2.31.0 python-telegram-bot~=20.7 python-dotenv~=1.0.1
+RUN python -m pip install requests~=2.31.0 python-telegram-bot~=20.7 python-dotenv~=1.0.1 schedule~=1.2.1
 
 WORKDIR /bot
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A [Telegram bot](https://core.telegram.org/bots/api) that running in Docker cont
 ## Configuration
 Just provide `BOT_TOKEN` in the `.env` file, you may use `.env.example` as example. Alnetratively you may provide `BOT_TOKEN` as enviromental variable.
 
+Optionally you can provide a `PULL_INTERVAL` in seconds to update rates every defined amount of seconds. Default value is 300. Value lower that 20 is not accepted, and lower that 30 is not recommended as it may lead throtling from Monobank side with answers like `{'errorDescription': 'Too many requests'}` 
+
 ## Running
 ### Build own Docker image
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -14,6 +14,13 @@ from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandl
 
 MONOBANK_API_URL = "https://api.monobank.ua/bank/currency"
 
+# Initialize exchange rates
+usd_rate = 0
+usd_rate_sell = 0
+eur_rate = 0
+eur_rate_sell = 0
+pln_rate = 0
+
 # Enable logging
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO

--- a/bot/main.py
+++ b/bot/main.py
@@ -49,14 +49,8 @@ async def rate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         data = response.json()
 
     except Exception as e:
-        await update.message.reply_text(f'Error fetching exchange rates: {str(e)}')
+        await update.message.reply_text(f'Error fetching exchange rates: {str(e)}, please try again later.')
         logger.error(f'Error fetching exchange rates: {str(e)}')
-
-    usd_rate = 0
-    usd_rate_sell = 0
-    eur_rate = 0
-    eur_rate_sell = 0
-    pln_rate = 0
     
     # pylint: disable=broad-except
     try:
@@ -85,7 +79,14 @@ def main() -> None:
         return
     
     logger.info("BOT_TOKEN is provided. Starting bot...")
-    
+
+    # Initialize empty exchange rates
+    usd_rate = 0
+    usd_rate_sell = 0
+    eur_rate = 0
+    eur_rate_sell = 0
+    pln_rate = 0
+
     # Create the Application and pass it your bot's token.
     application = Application.builder().token(TOKEN).build()
 
@@ -93,8 +94,6 @@ def main() -> None:
     application.add_handler(CommandHandler("start", start))
     application.add_handler(CommandHandler("help", help_command))
     application.add_handler(CommandHandler("rate", rate))
-
-    # on non command i.e message - echo the message on Telegram
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, help_command))
 
     # Run the bot until the user presses Ctrl-C

--- a/bot/main.py
+++ b/bot/main.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 def get_exchange_rates():
     logger.info("Fetching exchange rates from Monobank API")
     
+    # pylint: disable=global-statement
     global usd_rate, usd_rate_sell, eur_rate, eur_rate_sell, pln_rate
     # pylint: disable=broad-except
     try:
@@ -74,9 +75,10 @@ async def rate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     try:
         await update.message.reply_text(f'🇺🇸$ USD Buy Rate: {usd_rate}. Sell Rate: {usd_rate_sell}\n🇪🇺€ EUR Buy Rate: {eur_rate}. Sell Rate: {eur_rate_sell}\n🇵🇱zł PLN Exchange Rate: {pln_rate}')
         logger.info(f'Exchange rates sent to user {update.effective_user.id}')
-        
+
+    # pylint: disable=broad-except    
     except Exception as e:
-        await update.message.reply_text(f'Error heppened, please try again later.')
+        await update.message.reply_text('Error heppened, please try again later.')
         logger.error(f'Error fetching exchange rates: {str(e)}')
 
 def run_schedule():

--- a/bot/main.py
+++ b/bot/main.py
@@ -90,17 +90,35 @@ def main() -> None:
     # Load environment variables
     load_dotenv()
     TOKEN = os.getenv("BOT_TOKEN")
+    PULL_INTERVAL = os.getenv("PULL_INTERVAL")
+
+    if PULL_INTERVAL is None:
+        logger.info("PULL_INTERVAL is not defined, using default value 300")
+        PULL_INTERVAL = 300
+    
+    try:
+        PULL_INTERVAL = int(PULL_INTERVAL)
+    except ValueError:
+        logger.error("PULL_INTERVAL must be an integer")
+        logger.error("Using default value 300")
+        PULL_INTERVAL = 300
+    
+    if not 15 <= PULL_INTERVAL <= 3600:
+        logger.error("PULL_INTERVAL must be an integer between 15 and 3600")
+        logger.error("Using default value 300")
+        PULL_INTERVAL = 300
 
     # Ensure the token is set
     if TOKEN is None:
         logger.error("BOT_TOKEN is required")
         return
     
+    logger.info(f"PULL_INTERVAL is set to {PULL_INTERVAL}")
     logger.info("BOT_TOKEN is provided. Starting bot...")
 
     # Get rate once and schedule the job to fetch exchange rates every 1 minute
-    logger.info("Scheduling exchange rates fetching every 5 minutes")
-    schedule.every(5).minutes.do(get_exchange_rates)
+    logger.info(f'Scheduling exchange rates fetching every {PULL_INTERVAL} seconds.')
+    schedule.every(PULL_INTERVAL).seconds.do(get_exchange_rates)
     schedule.run_all()
     thread = threading.Thread(target=run_schedule)
     thread.start()


### PR DESCRIPTION
Issue #2 is a reason for this change. Pull interval is configurable with allowed values is between 15 and 3600 seconds, default value is 300 seconds. Any value less than 30 lead throttling from Monobank API side and from the practical perspective no reason to pull more often than 5 min (300 seconds) as Monobank updates exchange rates every 5 min

The same pull request adds a `dev` tag to container image, so you can use `docker pull ghcr.io/yurnov/xratebot:dev` to have latest image from `development` branch to use latest code that is not merged to `main` yet.