### PR TITLE
feat: add CSV logging for exchange rates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@
 BOT_TOKEN=your_bot_token
 # PULL_INTERVAL in seconds, must be between 30 and 3600, default is 300 (Optional)
 # PULL_INTERVAL=300
+# Save a rate to CSV file (Optional), default is False
+# LOG_RATE=False

--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ BOT_TOKEN=your_bot_token
 # PULL_INTERVAL=300
 # Save a rate to CSV file (Optional), default is False
 # LOG_RATE=False
+# Log level (Optional), default is INFO. Supoorted values: DEBUG, INFO, WARNING, ERROR, CRITICAL
+# LOG_LEVEL=INFO

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Bump version
+name: Release image to GHCR
 on:
   push:
     branches:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,8 @@ name: Run tests and build Docker image for development version
 on:
   push:
     branches:
-      - '!master'
+      - development
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+exchange_rates.csv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.0
 
-Feature: optinal logging exchange rates to CSV file
+Feature: [optinal logging exchange rates to CSV file](https://github.com/yurnov/exchange-rate-telegram-bot/issues/4)
 
 ## v0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+
+Feature: optinal logging exchange rates to CSV file
+
 ## v0.2.1
 
 Code is same as `v0.2.1`, just fix in README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## v0.3.0
 
-Feature: [optinal logging exchange rates to CSV file](https://github.com/yurnov/exchange-rate-telegram-bot/issues/4)
+[Optinal logging exchange rates to CSV file](https://github.com/yurnov/exchange-rate-telegram-bot/issues/4)
+Log level for application log is configurable
 
 ## v0.2.1
 
-Code is same as `v0.2.1`, just fix in README.md
+Code is same as `v0.2.0`, just fix in README.md
 
 ## v0.2.0
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Just provide `BOT_TOKEN` in the `.env` file, you may use `.env.example` as examp
 
 Optionally you can provide a `PULL_INTERVAL` in seconds to update rates every defined amount of seconds. Default value is 300. Value lower that 20 is not accepted, and lower that 30 is not recommended as it may lead throtling from Monobank side with answers like `{'errorDescription': 'Too many requests'}`
 
-Optionally bot can log exchange rates into CSV file `exchange_rates.csv`. Set `LOG_RATE` to `True` to enable logging. 
+Optionally bot can log exchange rates into CSV file `exchange_rates.csv`. Set `LOG_RATE` to `True` to enable logging.
+
+Default log level in INFO, you can override it with `LOG_LEVEL` varaible.
 
 ## Running
 ### Build own Docker image

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ A [Telegram bot](https://core.telegram.org/bots/api) that running in Docker cont
 ## Configuration
 Just provide `BOT_TOKEN` in the `.env` file, you may use `.env.example` as example. Alnetratively you may provide `BOT_TOKEN` as enviromental variable.
 
-Optionally you can provide a `PULL_INTERVAL` in seconds to update rates every defined amount of seconds. Default value is 300. Value lower that 20 is not accepted, and lower that 30 is not recommended as it may lead throtling from Monobank side with answers like `{'errorDescription': 'Too many requests'}` 
+Optionally you can provide a `PULL_INTERVAL` in seconds to update rates every defined amount of seconds. Default value is 300. Value lower that 20 is not accepted, and lower that 30 is not recommended as it may lead throtling from Monobank side with answers like `{'errorDescription': 'Too many requests'}`
+
+Optionally bot can log exchange rates into CSV file `exchange_rates.csv`. Set `LOG_RATE` to `True` to enable logging. 
 
 ## Running
 ### Build own Docker image
@@ -48,6 +50,13 @@ Alternatively, you may use enviroment varaible:
 docker pull ghcr.io/yurnov/xratebot:latest
 docker run --rm -d -e BOT_TOKEN="1111111111:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" ghcr.io/yurnov/xratebot:latest
 ```
+
+Do not forget to bind (mount) a CSV file in case when exchange rates loggin is enabled with `LOG_RATE`:
+```shell
+touch exchange_rates.csv && \
+docker run --rm -it --env-file .env -v ./exchange_rates.csv:/bot/exchange_rates.csv ghcr.io/yurnov/xratebot:latest
+```
+
 ### Ready-to-use Telegram Bot
 Start telegram conversation with [mono_rate_bot](https://t.me/mono_rate_bot) 
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -24,7 +24,6 @@ LOG_RATE = False
 
 # Enable initial logging
 logging.basicConfig(
-    # format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO
 )
 # set higher logging level for httpx to avoid all GET and POST requests being logged
@@ -54,12 +53,12 @@ def get_exchange_rates():
         logger.error(f'Error fetching exchange rates: {str(e)}')
     
     # Log exchange rates to CSV file
-    # format of CSV file: Date, Time, USD Buy Rate, USD Sell Rate, EUR Buy Rate, EUR Sell Rate, PLN Exchange Rate
+    # format of CSV file: Date Time, USD Buy Rate, USD Sell Rate, EUR Buy Rate, EUR Sell Rate, PLN Exchange Rate
     if LOG_RATE:
         if usd_rate != 0 or usd_rate_sell != 0 or eur_rate != 0 or eur_rate_sell != 0 or pln_rate != 0:
             try: 
                 with open('exchange_rates.csv', 'a', encoding='utf-8') as file:
-                    file.write(f'{time.strftime("%Y-%m-%d")},{time.strftime("%H:%M:%S")},{usd_rate},{usd_rate_sell},{eur_rate},{eur_rate_sell},{pln_rate}\n')
+                    file.write(f'{time.strftime("%Y-%m-%d %H:%M:%S")},{usd_rate},{usd_rate_sell},{eur_rate},{eur_rate_sell},{pln_rate}\n')
                 logger.info('Exchange rates written to exchange_rates.csv')
             except Exception as e:
                 logger.error(f'Error writing to exchange_rates.csv: {str(e)}')
@@ -144,7 +143,7 @@ def main() -> None:
     else:
         LOG_RATE = True
         logger.info(f'LOG_RATE is set to {LOG_RATE}')
-        logger.info("Format of CSV file: Date, Time, USD Buy Rate, USD Sell Rate, EUR Buy Rate, EUR Sell Rate, PLN Exchange Rate")
+        logger.info("Format of CSV file: Date Time, USD Buy Rate, USD Sell Rate, EUR Buy Rate, EUR Sell Rate, PLN Exchange Rate")
 
     # Get rate once and schedule the job to fetch exchange rates every 1 minute
     logger.info(f'Scheduling exchange rates fetching every {PULL_INTERVAL} seconds.')

--- a/bot/main.py
+++ b/bot/main.py
@@ -57,7 +57,7 @@ def get_exchange_rates():
     if LOG_RATE:
         if usd_rate != 0 or usd_rate_sell != 0 or eur_rate != 0 or eur_rate_sell != 0 or pln_rate != 0:
             try: 
-                with open('exchange_rates.csv', 'a') as file:
+                with open('exchange_rates.csv', 'a', encoding='utf-8') as file:
                     file.write(f'{time.strftime("%Y-%m-%d")},{time.strftime("%H:%M:%S")},{usd_rate},{usd_rate_sell},{eur_rate},{eur_rate_sell},{pln_rate}\n')
                 logger.info('Exchange rates written to exchange_rates.csv')
             except Exception as e:
@@ -102,6 +102,7 @@ def run_schedule():
 
 def main() -> None:
 
+    # pylint: disable=global-statement
     global LOG_RATE
 
     # Load environment variables

--- a/bot/main.py
+++ b/bot/main.py
@@ -55,12 +55,15 @@ def get_exchange_rates():
     # Log exchange rates to CSV file
     # format of CSV file: Date, Time, USD Buy Rate, USD Sell Rate, EUR Buy Rate, EUR Sell Rate, PLN Exchange Rate
     if LOG_RATE:
-        try: 
-            with open('exchange_rates.csv', 'a') as file:
-                file.write(f'{time.strftime("%Y-%m-%d")},{time.strftime("%H:%M:%S")},{usd_rate},{usd_rate_sell},{eur_rate},{eur_rate_sell},{pln_rate}\n')
-            logger.info('Exchange rates written to exchange_rates.csv')
-        except Exception as e:
-            logger.error(f'Error writing to exchange_rates.csv: {str(e)}')
+        if usd_rate != 0 or usd_rate_sell != 0 or eur_rate != 0 or eur_rate_sell != 0 or pln_rate != 0:
+            try: 
+                with open('exchange_rates.csv', 'a') as file:
+                    file.write(f'{time.strftime("%Y-%m-%d")},{time.strftime("%H:%M:%S")},{usd_rate},{usd_rate_sell},{eur_rate},{eur_rate_sell},{pln_rate}\n')
+                logger.info('Exchange rates written to exchange_rates.csv')
+            except Exception as e:
+                logger.error(f'Error writing to exchange_rates.csv: {str(e)}')
+        else:
+            logger.error('Exchange rates are not fetched, not writing to exchange_rates.csv')
 
 # pylint: disable=unused-argument
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/bot/main.py
+++ b/bot/main.py
@@ -22,8 +22,9 @@ eur_rate_sell = 0
 pln_rate = 0
 LOG_RATE = False
 
-# Enable logging
+# Enable initial logging
 logging.basicConfig(
+    # format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO
 )
 # set higher logging level for httpx to avoid all GET and POST requests being logged
@@ -110,6 +111,7 @@ def main() -> None:
     TOKEN = os.getenv("BOT_TOKEN")
     PULL_INTERVAL = os.getenv("PULL_INTERVAL")
     LOG_RATE = os.getenv("LOG_RATE")
+    LOG_LEVEL = os.getenv("LOG_LEVEL")
 
     if PULL_INTERVAL is None:
         logger.info("PULL_INTERVAL is not defined, using default value 300")
@@ -151,8 +153,17 @@ def main() -> None:
     thread = threading.Thread(target=run_schedule)
     thread.start()
 
+    if LOG_LEVEL is None or LOG_LEVEL.lower() not in ['debug', 'info', 'warning', 'error', 'critical']:
+        LOG_LEVEL = 'info'
+        logger.info('LOG_LEVEL is not defined or invalid, using default value info')
+
     # Create the Application and pass it your bot's token.
     application = Application.builder().token(TOKEN).build()
+
+    # Set runtime logging level
+    if LOG_LEVEL.lower() != 'info':
+        logger.info(f'Switching LOG_LEVEL to user-defined value {LOG_LEVEL.upper()}')
+    logger.setLevel(LOG_LEVEL.upper())
 
     # on different commands - answer in Telegram
     application.add_handler(CommandHandler("start", start))


### PR DESCRIPTION
To analyze historical changes in exchange rates, I added the optional possibility to write exchange rates to a CSV file. 

It will allow you to create charts like this 
![image](https://github.com/yurnov/exchange-rate-telegram-bot/assets/22106917/92f5c77b-2e8f-437e-b3ee-0f13234028e5)

The same PR adds a configuration of logs level that allows to produce of fewer docker logs.

This PR is aimed to close issue #4 
