### PR TITLE
perf(backup): tune S3 backup sidecar for low-resource hosts

### DIFF
--- a/.env.backup.example
+++ b/.env.backup.example
@@ -18,10 +18,15 @@ S3_SECRET_KEY=your-secret-key
 # S3_PREFIX=backups/
 # Optional: AWS region (default: us-east-1)
 # S3_REGION=us-east-1
+# Optional: Storage class for uploaded objects (default: the provider's default).
+# Infrequent-access classes are much cheaper for backups that are never read.
+# S3_STORAGE_CLASS=STANDARD_IA
 
 # Optional: Backup interval in seconds (default: 86400 = 24 hours)
 # BACKUP_INTERVAL=86400
-# Optional: Number of backup copies to retain (default: 7)
+# Optional: Number of backup copies to retain (default: 7).
+# Set to 0 to skip cleanup entirely and let an S3 lifecycle rule expire old
+# backups server-side — that costs the host nothing at all.
 # BACKUP_RETENTION=7
 # Optional: Backup mode — "scheduled" (continuous) or "once" (single run and exit)
 # BACKUP_MODE=once
@@ -31,3 +36,53 @@ S3_SECRET_KEY=your-secret-key
 # DB_PATH=data/exchange_rates.db
 # Optional: Log level (default: INFO)
 # LOG_LEVEL=INFO
+
+# --- Resource tuning ---------------------------------------------------------
+# The defaults are tuned for a small VM (512 MiB RAM, one shared vCPU) and rarely
+# need changing. See the "Backup resource usage" section of README.md.
+
+# Optional: Directory used to stage the snapshot before upload (default: system temp).
+# Point this at a mounted volume so the snapshot does not land in the container
+# layer. docker-compose.yml already sets this to /backup/work.
+# BACKUP_TMPDIR=/backup/work
+
+# Optional: Snapshot method (default: auto)
+#   auto   — VACUUM INTO, falling back to the online backup API
+#   vacuum — VACUUM INTO only (smallest output, never restarted by concurrent writes)
+#   copy   — online backup API only
+# BACKUP_METHOD=auto
+
+# Optional: Gzip the snapshot before uploading (default: true).
+# Typically shrinks the upload by 5-10x, which saves far more time than the
+# compression costs.
+# BACKUP_COMPRESS=true
+# Optional: Gzip level, 1-9 (default: 1). Level 1 is deliberate — on a shared vCPU
+# the extra few percent of ratio at higher levels is not worth the CPU.
+# BACKUP_COMPRESS_LEVEL=1
+
+# Optional: Concurrent multipart upload threads (default: 1). boto3 defaults to 10,
+# which holds ~80 MiB of buffers and runs TLS on ten threads at once — enough to
+# trigger the OOM killer on a 512 MiB host.
+# BACKUP_UPLOAD_CONCURRENCY=1
+# Optional: Multipart upload threshold and chunk size, in MiB (default: 64 and 16)
+# BACKUP_MULTIPART_THRESHOLD=64
+# BACKUP_MULTIPART_CHUNKSIZE=16
+
+# Optional: CPU niceness increment, 0-19 (default: 19 = lowest priority)
+# BACKUP_NICE=19
+# Optional: Request the idle I/O scheduling class (default: true)
+# BACKUP_IONICE=true
+# Optional: Release the page cache for files read and written (default: true).
+# This is what stops a multi-hundred-megabyte snapshot from evicting everything
+# else on the host and stalling it in writeback.
+# BACKUP_DROP_CACHE=true
+# Optional: Abort a backup cycle after N seconds, 0 disables (default: 3600)
+# BACKUP_TIMEOUT=3600
+
+# Optional: Write a JSON summary of every cycle here. On a volume, this survives an
+# OOM kill and is often the only way to see what happened.
+# docker-compose.yml already sets this to /backup/work/last_backup.json.
+# BACKUP_STATUS_FILE=/backup/work/last_backup.json
+# Optional: Mirror logs to a file, useful when the host is too loaded for ssh.
+# docker-compose.yml already sets this to /backup/work/backup.log.
+# BACKUP_LOG_FILE=/backup/work/backup.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 [Added support of backup sidecar container](https://github.com/yurnov/exchange-rate-telegram-bot/pull/48)
 
+Backup sidecar tuned for low-resource hosts:
+- Snapshots are taken with `VACUUM INTO` (smaller output, not restarted by concurrent writes) and staged on a mounted volume instead of the container layer
+- Page cache is flushed and released while writing, so a large snapshot no longer stalls the whole host in writeback
+- Snapshots are gzipped (level 1 by default) before upload
+- Uploads use a single transfer thread with bounded buffers instead of boto3's ten concurrent parts
+- The process runs at `nice 19` in the idle I/O class, and the container has memory, CPU and PID caps
+- Old backups are deleted in batches, or left to an S3 lifecycle rule with `BACKUP_RETENTION=0`
+- Added per-phase timings, a JSON status file, an optional log file, a hard timeout and clean `SIGTERM` handling
+
 ## v0.9.0
 
 [Added support of Turkish lira](https://github.com/yurnov/exchange-rate-telegram-bot/pull/46)

--- a/README.md
+++ b/README.md
@@ -244,9 +244,15 @@ docker compose run --rm -e BACKUP_MODE=once backup
 docker run --rm \
   --env-file .env.backup \
   -e BACKUP_MODE=once \
+  -e BACKUP_TMPDIR=/backup/work \
+  -e BACKUP_STATUS_FILE=/backup/work/last_backup.json \
+  --memory 192m --cpus 0.5 \
   -v ./data:/bot/data:ro \
+  -v exchange-rate-telegram-bot_backup-work:/backup/work \
   ghcr.io/yurnov/xratebot-backup:latest
 ```
+
+> The data volume is mounted read-only. SQLite needs the `-shm` file to read a database in WAL mode and cannot create one on a read-only mount, so the bot container must be running (it holds that file open). If it is not, the backup fails with `attempt to write a readonly database`.
 
 ### Running Scheduled Backup
 
@@ -254,6 +260,48 @@ To run the backup container continuously to process backups on a set schedule (d
 
 ```bash
 docker compose --profile backup up -d
+```
+
+### Backup Resource Usage
+
+The backup is designed to stay out of the way on a small VM (512 MiB RAM, one shared vCPU), where a naive "copy the database, then upload it" backup can drive the load average into the double digits and make the host unreachable. What it does:
+
+| Behaviour | Why it matters |
+| --- | --- |
+| `VACUUM INTO` snapshot (`BACKUP_METHOD`) | Skips free pages, so the snapshot is smaller than the database, and — unlike the online backup API — it is never restarted from scratch when the bot writes mid-copy |
+| Snapshot staged on a mounted volume (`BACKUP_TMPDIR`) | Keeps a multi-hundred-megabyte temporary file out of the container layer, and off `tmpfs`, where it would consume RAM |
+| `fsync` + `posix_fadvise(DONTNEED)` every 64 MiB (`BACKUP_DROP_CACHE`) | The kernel never accumulates the whole snapshot as dirty pages, so it never stalls the host — including `sshd` — while flushing them |
+| Gzip level 1 by default (`BACKUP_COMPRESS`, `BACKUP_COMPRESS_LEVEL`) | Typically a 5-10x smaller upload for very little CPU; shortening the upload also saves TLS work |
+| Single upload thread with bounded buffers (`BACKUP_UPLOAD_CONCURRENCY`, `BACKUP_MULTIPART_CHUNKSIZE`) | boto3 defaults to 10 concurrent 8 MiB parts — ~80 MiB of buffers plus TLS on ten threads, which is enough to get the process OOM-killed before it can log anything |
+| `nice 19` and the idle I/O class (`BACKUP_NICE`, `BACKUP_IONICE`) | The backup only gets CPU and disk that nothing else wants, so the bot stays responsive |
+| Memory and CPU caps in `docker-compose.yml` | If a backup no longer fits, it is OOM-killed inside its own cgroup instead of taking the host down |
+| Batched retention deletes, or none at all (`BACKUP_RETENTION`) | One `DeleteObjects` call instead of one request per object; `BACKUP_RETENTION=0` hands expiry to an S3 lifecycle rule, which costs the host nothing |
+| Hard timeout (`BACKUP_TIMEOUT`) | A stalled upload fails and is retried instead of hanging forever |
+
+For a ~0.5 GB database this typically means around 50-100 MiB uploaded per run and a peak RSS well under 100 MiB.
+
+Tuning knobs live in `.env.backup`; the container's memory and CPU caps live in `docker-compose.yml`:
+
+```yaml
+    cpus: 0.5
+    mem_limit: 192m
+    memswap_limit: 192m
+```
+
+### Troubleshooting Backups
+
+Every cycle writes a JSON summary and a log file to the `backup-work` volume, so a failure can be diagnosed after the fact — useful when the host was too busy to accept an ssh connection at the time:
+
+```bash
+docker run --rm -v exchange-rate-telegram-bot_backup-work:/w alpine cat /w/last_backup.json
+docker run --rm -v exchange-rate-telegram-bot_backup-work:/w alpine tail -50 /w/backup.log
+```
+
+The `phase` field of `last_backup.json` (`snapshot`, `compress`, `upload`, `cleanup`, `done`) shows where a run stopped. If the file says nothing at all and the container exited unexpectedly, the process was killed rather than failing:
+
+```bash
+docker inspect --format '{{.State.OOMKilled}} {{.State.ExitCode}}' exchange-rate-bot-backup
+dmesg -T | grep -i -E 'oom|killed process'
 ```
 
 ## Technical Details

--- a/bot/backup.py
+++ b/bot/backup.py
@@ -4,10 +4,17 @@
 """
 S3 backup module for SQLite database.
 
-This script creates safe backups of the SQLite database using the online backup API
-and uploads them to S3-compatible object storage. It can run in two modes:
+This script creates safe backups of the SQLite database and uploads them to
+S3-compatible object storage. It can run in two modes:
 - Scheduled mode (default): Runs continuously, creating backups at a configurable interval
 - One-shot mode: Creates a single backup and exits (for cron jobs / Kubernetes Jobs)
+
+The implementation is tuned for small hosts (512 MiB RAM, one shared vCPU): the
+snapshot is staged on a real filesystem instead of the container layer, the page
+cache is dropped as the file is written so the kernel never has to flush hundreds
+of megabytes of dirty pages at once, the upload uses a single transfer thread with
+bounded buffers, and the process lowers its own CPU and I/O priority so it can
+never starve the bot (or sshd) on the same box.
 
 Usage:
     python backup.py                  # Scheduled mode (default)
@@ -23,15 +30,37 @@ Optional environment variables:
     S3_ENDPOINT_URL    - S3-compatible endpoint URL (default: None, uses AWS)
     S3_PREFIX          - Key prefix for backup files (default: backups/)
     S3_REGION          - AWS region (default: us-east-1)
+    S3_STORAGE_CLASS   - Storage class for uploaded objects (default: provider default)
     BACKUP_INTERVAL    - Seconds between backups in scheduled mode (default: 86400)
-    BACKUP_RETENTION   - Number of backup copies to retain (default: 7)
+    BACKUP_RETENTION   - Number of backup copies to retain, 0 disables cleanup (default: 7)
     DB_PATH            - Path to SQLite database (default: data/exchange_rates.db)
     BACKUP_MODE        - "scheduled" (default) or "once"
     LOG_LEVEL          - Logging level (default: INFO)
+
+Resource-tuning environment variables:
+    BACKUP_TMPDIR         - Directory for staging the snapshot (default: system temp)
+    BACKUP_METHOD         - "auto" (default), "vacuum" or "copy"
+    BACKUP_COMPRESS       - Gzip the snapshot before upload (default: true)
+    BACKUP_COMPRESS_LEVEL - Gzip level 1-9, low is cheap on CPU (default: 1)
+    BACKUP_NICE           - Niceness increment for this process, 0-19 (default: 19)
+    BACKUP_IONICE         - Request the idle I/O scheduling class (default: true)
+    BACKUP_DROP_CACHE     - Drop page cache for files read/written (default: true)
+    BACKUP_TIMEOUT        - Abort a backup cycle after N seconds, 0 disables (default: 3600)
+    BACKUP_UPLOAD_CONCURRENCY   - Concurrent multipart upload threads (default: 1)
+    BACKUP_MULTIPART_THRESHOLD  - Multipart upload threshold in MiB (default: 64)
+    BACKUP_MULTIPART_CHUNKSIZE  - Multipart chunk size in MiB (default: 16)
+    BACKUP_STATUS_FILE    - Write a JSON status document here after every cycle
+    BACKUP_LOG_FILE       - Mirror logs to this file (survives an unreachable host)
 """
 
+import ctypes
+import gzip
+import json
 import logging
 import os
+import platform
+import shutil
+import signal
 import sqlite3
 import sys
 import time
@@ -40,6 +69,7 @@ from datetime import datetime, timezone
 
 try:
     import boto3
+    from botocore.config import Config as BotocoreConfig
     from botocore.exceptions import ClientError, NoCredentialsError
 except ImportError:
     boto3 = None
@@ -49,41 +79,282 @@ from dotenv import load_dotenv
 logging.basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Copy in 4 MiB slices: large enough to keep syscall overhead irrelevant, small
+# enough that the amount of dirty page cache in flight stays bounded on a 512 MiB host.
+COPY_CHUNK_SIZE = 4 * 1024 * 1024
 
-def create_backup(db_path: str, backup_path: str) -> bool:
+# Flush and drop the page cache after every 64 MiB written. Without this the kernel
+# accumulates the whole snapshot as dirty pages and then stalls every process on the
+# host (including sshd) while it writes them back.
+FLUSH_INTERVAL = 64 * 1024 * 1024
+
+MIB = 1024 * 1024
+
+# ioprio_set(2) syscall numbers, per architecture. Used to put the backup in the
+# idle I/O class so it only gets disk bandwidth nobody else wants.
+IOPRIO_SET_SYSCALL = {'x86_64': 251, 'aarch64': 30, 'armv7l': 314, 'i686': 289}
+IOPRIO_WHO_PROCESS = 1
+IOPRIO_CLASS_IDLE = 3
+IOPRIO_CLASS_SHIFT = 13
+
+
+class BackupTimeout(Exception):
+    """Raised when a backup cycle exceeds BACKUP_TIMEOUT."""
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    """Read a boolean environment variable."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in ['true', '1', 'yes', 'on', 'enabled']
+
+
+def _env_int(name: str, default: int, minimum: int = None, maximum: int = None) -> int:
+    """Read an integer environment variable, falling back to the default when invalid."""
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == '':
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(f"Invalid value for {name}: {raw!r}, using default {default}")
+        return default
+    if minimum is not None and value < minimum:
+        logger.warning(f"{name}={value} is below minimum {minimum}, using {minimum}")
+        return minimum
+    if maximum is not None and value > maximum:
+        logger.warning(f"{name}={value} is above maximum {maximum}, using {maximum}")
+        return maximum
+    return value
+
+
+def _human(size: int) -> str:
+    """Format a byte count for logging."""
+    value = float(size)
+    for unit in ['B', 'KiB', 'MiB', 'GiB']:
+        if value < 1024 or unit == 'GiB':
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} GiB"
+
+
+def _peak_rss() -> str:
+    """Return the peak resident set size of this process, if the kernel exposes it."""
+    try:
+        with open('/proc/self/status', 'r', encoding='utf-8') as status:
+            for line in status:
+                if line.startswith('VmHWM:'):
+                    return line.split(':', 1)[1].strip()
+    except OSError:
+        pass
+    return 'unknown'
+
+
+def lower_process_priority(nice_increment: int, use_ionice: bool) -> None:
     """
-    Create a safe SQLite backup using the online backup API.
+    Lower CPU and I/O priority of this process.
 
-    This handles WAL mode correctly and produces a consistent backup file
-    even while the database is being written to by another process.
+    On a single shared vCPU this is what keeps the bot responsive (and the host
+    reachable over ssh) while a multi-hundred-megabyte snapshot is being copied.
+
+    Args:
+        nice_increment: Niceness to add, 0-19. Higher means lower priority.
+        use_ionice: Whether to request the idle I/O scheduling class.
+    """
+    if nice_increment > 0:
+        try:
+            logger.debug(f"Process niceness set to {os.nice(nice_increment)}")
+        except OSError as e:
+            logger.warning(f"Could not lower CPU priority: {str(e)}")
+
+    if not use_ionice:
+        return
+
+    syscall_number = IOPRIO_SET_SYSCALL.get(platform.machine())
+    if syscall_number is None:
+        logger.debug(f"No ioprio_set syscall number known for {platform.machine()}, skipping ionice")
+        return
+
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        priority = IOPRIO_CLASS_IDLE << IOPRIO_CLASS_SHIFT
+        if libc.syscall(syscall_number, IOPRIO_WHO_PROCESS, 0, priority) != 0:
+            logger.debug(f"ioprio_set failed with errno {ctypes.get_errno()}, keeping default I/O priority")
+        else:
+            logger.debug("I/O priority set to idle class")
+    except (OSError, AttributeError) as e:
+        logger.debug(f"Could not set I/O priority: {str(e)}")
+
+
+def _drop_cache(fd: int, drop_cache: bool) -> None:
+    """Tell the kernel the pages of this file descriptor are no longer needed."""
+    if not drop_cache:
+        return
+    try:
+        os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
+    except (AttributeError, OSError):
+        pass
+
+
+def _flush_and_drop(fd: int, drop_cache: bool) -> None:
+    """Flush written data to disk and release its page cache."""
+    try:
+        os.fsync(fd)
+    except OSError as e:
+        logger.debug(f"fsync failed: {str(e)}")
+    _drop_cache(fd, drop_cache)
+
+
+def create_snapshot(db_path: str, snapshot_path: str, method: str, drop_cache: bool) -> bool:
+    """
+    Create a consistent snapshot of the SQLite database.
+
+    Two strategies are available:
+    - "vacuum": VACUUM INTO, which reads the database in a single read transaction
+      and writes a defragmented copy. It is not restarted when the bot writes to the
+      source, and the output is smaller because free pages are not copied.
+    - "copy": the online backup API. Kept as a fallback for old SQLite builds. Note
+      that this API restarts the copy from scratch whenever the source is modified
+      mid-flight, which on a slow host can prevent it from ever finishing.
+
+    Both handle WAL mode correctly and are safe while the bot is writing.
 
     Args:
         db_path: Path to the source SQLite database
-        backup_path: Path for the backup file
+        snapshot_path: Path for the snapshot file (must not exist for "vacuum")
+        method: "auto", "vacuum" or "copy"
+        drop_cache: Whether to release the page cache after writing
 
     Returns:
-        True if backup was successful, False otherwise
+        True if the snapshot was created, False otherwise
     """
     if not os.path.exists(db_path):
         logger.error(f"Source database not found: {db_path}")
         return False
 
+    # Use a longer timeout than the main bot's busy_timeout (5s) because the
+    # snapshot reads the entire database and may need to wait for ongoing writes.
+    source_conn = None
     try:
-        # Use longer timeout than the main bot's busy_timeout (5s) because
-        # backup reads the entire database and may need to wait for ongoing writes
         source_conn = sqlite3.connect(db_path, timeout=30)
-        backup_conn = sqlite3.connect(backup_path)
-        source_conn.backup(backup_conn)
-        backup_conn.close()
-        source_conn.close()
-        logger.info(f"Database backup created: {backup_path}")
+
+        if method in ('auto', 'vacuum'):
+            try:
+                source_conn.execute("VACUUM INTO ?", (snapshot_path,))
+                logger.debug("Snapshot created with VACUUM INTO")
+                _post_write_flush(snapshot_path, drop_cache)
+                return True
+            except sqlite3.Error as e:
+                if method == 'vacuum':
+                    logger.error(f"VACUUM INTO failed: {str(e)}")
+                    return False
+                logger.warning(f"VACUUM INTO unavailable ({str(e)}), falling back to the online backup API")
+                # A failed VACUUM INTO may leave a partial file behind.
+                if os.path.exists(snapshot_path):
+                    os.unlink(snapshot_path)
+
+        backup_conn = sqlite3.connect(snapshot_path)
+        try:
+            # The destination is a throwaway file that is uploaded and deleted, so
+            # there is no reason to pay for journalling or per-page fsyncs on it.
+            backup_conn.execute("PRAGMA journal_mode=OFF")
+            backup_conn.execute("PRAGMA synchronous=OFF")
+            source_conn.backup(backup_conn)
+        finally:
+            backup_conn.close()
+        _post_write_flush(snapshot_path, drop_cache)
         return True
+
     except Exception as e:  # pylint: disable=broad-exception-caught
-        logger.error(f"Error creating database backup: {str(e)}")
+        logger.error(f"Error creating database snapshot: {str(e)}")
+        if 'readonly' in str(e).lower():
+            # Reading a WAL database needs the -shm file, which SQLite cannot create
+            # on a read-only mount. It exists as long as the bot holds the database
+            # open, so this normally only happens when the bot is not running.
+            logger.error(
+                f"The database is on a read-only mount and no shared-memory file "
+                f"({os.path.basename(db_path)}-shm) is available. Start the bot container first, or mount "
+                f"the data volume read-write for the backup container."
+            )
+        return False
+    finally:
+        if source_conn is not None:
+            source_conn.close()
+        # The source pages were read once and will not be read again; handing them
+        # back keeps the bot's working set in a page cache this small.
+        _drop_source_cache(db_path, drop_cache)
+
+
+def _post_write_flush(path: str, drop_cache: bool) -> None:
+    """Flush a file written by SQLite and drop its page cache."""
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        _flush_and_drop(fd, drop_cache)
+    finally:
+        os.close(fd)
+
+
+def _drop_source_cache(db_path: str, drop_cache: bool) -> None:
+    """Release the page cache held for the source database."""
+    if not drop_cache:
+        return
+    try:
+        fd = os.open(db_path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        _drop_cache(fd, drop_cache)
+    finally:
+        os.close(fd)
+
+
+def compress_file(source_path: str, dest_path: str, level: int, drop_cache: bool) -> bool:
+    """
+    Gzip a file in bounded-size chunks.
+
+    Level 1 is deliberate: SQLite pages compress well even at the cheapest setting,
+    and on a shared vCPU the CPU saved is worth far more than the extra few percent
+    of ratio. Compressing also shortens the upload, which is itself CPU work (TLS).
+
+    Args:
+        source_path: File to compress
+        dest_path: Destination .gz path
+        level: Gzip compression level, 1-9
+        drop_cache: Whether to release the page cache while writing
+
+    Returns:
+        True if compression succeeded, False otherwise
+    """
+    try:
+        written_since_flush = 0
+        with open(source_path, 'rb') as src, open(dest_path, 'wb') as raw_dst:
+            with gzip.GzipFile(fileobj=raw_dst, mode='wb', compresslevel=level) as dst:
+                while True:
+                    chunk = src.read(COPY_CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    dst.write(chunk)
+                    written_since_flush += len(chunk)
+                    if written_since_flush >= FLUSH_INTERVAL:
+                        dst.flush()
+                        raw_dst.flush()
+                        _flush_and_drop(raw_dst.fileno(), drop_cache)
+                        _drop_cache(src.fileno(), drop_cache)
+                        written_since_flush = 0
+            raw_dst.flush()
+            _flush_and_drop(raw_dst.fileno(), drop_cache)
+            _drop_cache(src.fileno(), drop_cache)
+        return True
+    except OSError as e:
+        logger.error(f"Error compressing snapshot: {str(e)}")
         return False
 
 
-def upload_to_s3(file_path: str, bucket: str, key: str, s3_client) -> bool:
+def upload_to_s3(file_path: str, bucket: str, key: str, s3_client, transfer_config, extra_args=None) -> bool:
     """
     Upload a file to S3-compatible storage.
 
@@ -92,12 +363,14 @@ def upload_to_s3(file_path: str, bucket: str, key: str, s3_client) -> bool:
         bucket: S3 bucket name
         key: S3 object key
         s3_client: Configured boto3 S3 client
+        transfer_config: boto3 TransferConfig bounding threads and buffer sizes
+        extra_args: Optional dict of extra S3 arguments (storage class, content type)
 
     Returns:
         True if upload was successful, False otherwise
     """
     try:
-        s3_client.upload_file(file_path, bucket, key)
+        s3_client.upload_file(file_path, bucket, key, ExtraArgs=extra_args, Config=transfer_config)
         logger.info(f"Uploaded backup to s3://{bucket}/{key}")
         return True
     except ClientError as e:
@@ -112,15 +385,25 @@ def cleanup_old_backups(bucket: str, prefix: str, retention: int, s3_client) -> 
     """
     Remove old backups from S3, keeping only the most recent ones.
 
+    Objects are deleted in batches of up to 1000 keys instead of one request per
+    object. Set BACKUP_RETENTION=0 to skip this entirely and let an S3 lifecycle
+    rule expire old backups server-side, which costs the host nothing at all.
+
     Args:
         bucket: S3 bucket name
         prefix: S3 key prefix for backups
         retention: Number of recent backups to keep
         s3_client: Configured boto3 S3 client
     """
+    if retention <= 0:
+        logger.info("Retention disabled (BACKUP_RETENTION=0), leaving cleanup to the bucket lifecycle policy")
+        return
+
     try:
-        response = s3_client.list_objects_v2(Bucket=bucket, Prefix=prefix)
-        objects = response.get('Contents', [])
+        objects = []
+        paginator = s3_client.get_paginator('list_objects_v2')
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            objects.extend(page.get('Contents', []))
 
         if len(objects) <= retention:
             logger.info(f"Backup count ({len(objects)}) within retention limit ({retention}), no cleanup needed")
@@ -128,11 +411,13 @@ def cleanup_old_backups(bucket: str, prefix: str, retention: int, s3_client) -> 
 
         # Sort by LastModified, oldest first
         objects.sort(key=lambda x: x['LastModified'])
-        to_delete = objects[: len(objects) - retention]
+        to_delete = [{'Key': obj['Key']} for obj in objects[: len(objects) - retention]]
 
-        for obj in to_delete:
-            s3_client.delete_object(Bucket=bucket, Key=obj['Key'])
-            logger.info(f"Deleted old backup: s3://{bucket}/{obj['Key']}")
+        for batch_start in range(0, len(to_delete), 1000):
+            batch = to_delete[batch_start : batch_start + 1000]
+            response = s3_client.delete_objects(Bucket=bucket, Delete={'Objects': batch, 'Quiet': True})
+            for error in response.get('Errors', []):
+                logger.error(f"Failed to delete {error.get('Key')}: {error.get('Message')}")
 
         logger.info(f"Cleanup complete: removed {len(to_delete)} old backup(s)")
 
@@ -142,7 +427,7 @@ def cleanup_old_backups(bucket: str, prefix: str, retention: int, s3_client) -> 
         logger.error(f"Unexpected error during backup cleanup: {str(e)}")
 
 
-def create_s3_client(endpoint_url: str, access_key: str, secret_key: str, region: str):
+def create_s3_client(endpoint_url: str, access_key: str, secret_key: str, region: str, max_concurrency: int):
     """
     Create a boto3 S3 client with the given configuration.
 
@@ -151,6 +436,7 @@ def create_s3_client(endpoint_url: str, access_key: str, secret_key: str, region
         access_key: Access key ID
         secret_key: Secret access key
         region: AWS region
+        max_concurrency: Upload concurrency, used to size the connection pool
 
     Returns:
         Configured boto3 S3 client
@@ -159,6 +445,15 @@ def create_s3_client(endpoint_url: str, access_key: str, secret_key: str, region
         'aws_access_key_id': access_key,
         'aws_secret_access_key': secret_key,
         'region_name': region,
+        # Explicit timeouts turn a silently stalled upload into a retried (and
+        # eventually logged) failure instead of a container that hangs forever.
+        'config': BotocoreConfig(
+            connect_timeout=15,
+            read_timeout=120,
+            retries={'mode': 'adaptive', 'max_attempts': 5},
+            max_pool_connections=max(max_concurrency, 2),
+            tcp_keepalive=True,
+        ),
     }
     if endpoint_url:
         client_kwargs['endpoint_url'] = endpoint_url
@@ -166,40 +461,259 @@ def create_s3_client(endpoint_url: str, access_key: str, secret_key: str, region
     return boto3.client('s3', **client_kwargs)
 
 
-def run_backup(db_path: str, s3_client, bucket: str, prefix: str, retention: int) -> bool:
+def create_transfer_config(max_concurrency: int, threshold_mib: int, chunksize_mib: int):
     """
-    Execute a single backup cycle: create backup, upload to S3, cleanup old backups.
+    Build a TransferConfig that bounds upload memory and CPU.
+
+    boto3 defaults to 10 concurrent 8 MiB parts, so an upload can hold ~80 MiB of
+    buffers and run TLS encryption on ten threads at once. On a 512 MiB host with one
+    shared vCPU that is enough to trigger the OOM killer, which kills the process
+    before it can log anything.
 
     Args:
-        db_path: Path to the SQLite database
+        max_concurrency: Number of concurrent part uploads
+        threshold_mib: Size above which multipart upload kicks in
+        chunksize_mib: Size of each multipart chunk
+
+    Returns:
+        Configured boto3 TransferConfig
+    """
+    # Imported lazily so the module can still be imported without boto3 installed.
+    from boto3.s3.transfer import TransferConfig  # pylint: disable=import-outside-toplevel
+
+    return TransferConfig(
+        multipart_threshold=threshold_mib * MIB,
+        multipart_chunksize=chunksize_mib * MIB,
+        max_concurrency=max_concurrency,
+        use_threads=max_concurrency > 1,
+        max_io_queue=max(max_concurrency * 2, 2),
+    )
+
+
+def write_status(status_file: str, payload: dict) -> None:
+    """
+    Write a JSON status document describing the last backup cycle.
+
+    Placed on a mounted volume this is the only artefact that survives an OOM kill,
+    so it is often the only way to find out what happened on a host that was too
+    loaded to accept an ssh connection.
+
+    Args:
+        status_file: Destination path (no-op when empty)
+        payload: Status fields to serialise
+    """
+    if not status_file:
+        return
+    try:
+        os.makedirs(os.path.dirname(status_file) or '.', exist_ok=True)
+        tmp_path = f"{status_file}.tmp"
+        with open(tmp_path, 'w', encoding='utf-8') as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+        os.replace(tmp_path, status_file)
+    except OSError as e:
+        logger.warning(f"Could not write status file {status_file}: {str(e)}")
+
+
+def _has_room_to_stage(db_path: str, work_dir: str, status: dict) -> bool:
+    """
+    Check that the staging directory can hold a snapshot of the database.
+
+    The snapshot is never larger than the source, so the source size plus a small
+    margin for the compressed copy is a safe estimate.
+
+    Args:
+        db_path: Path to the source SQLite database
+        work_dir: Directory the snapshot will be staged in
+        status: Status dictionary to annotate on failure
+
+    Returns:
+        True if there is enough free space, False otherwise
+    """
+    try:
+        needed = int(os.path.getsize(db_path) * 1.2)
+        free = shutil.disk_usage(work_dir).free
+    except OSError as e:
+        logger.debug(f"Could not check free space in {work_dir}: {str(e)}")
+        return True
+
+    if free < needed:
+        message = f"Not enough space in {work_dir}: {_human(free)} free, {_human(needed)} needed"
+        logger.error(message)
+        status['error'] = message
+        return False
+    return True
+
+
+def run_backup(config: dict, s3_client, transfer_config) -> bool:
+    """
+    Execute a single backup cycle: snapshot, optional compression, upload, cleanup.
+
+    Each phase is timed and logged separately so a run that dies part-way through
+    can be attributed to a specific phase after the fact.
+
+    Args:
+        config: Resolved configuration dictionary
         s3_client: Configured boto3 S3 client
-        bucket: S3 bucket name
-        prefix: S3 key prefix
-        retention: Number of backups to retain
+        transfer_config: boto3 TransferConfig for the upload
 
     Returns:
         True if backup was successful, False otherwise
     """
-    timestamp = datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')
-    backup_key = f"{prefix}exchange_rates_{timestamp}.db"
+    started_at = datetime.now(timezone.utc)
+    timestamp = started_at.strftime('%Y%m%d_%H%M%S')
+    suffix = '.db.gz' if config['compress'] else '.db'
+    backup_key = f"{config['s3_prefix']}exchange_rates_{timestamp}{suffix}"
 
-    # Create backup in a temporary file
-    with tempfile.NamedTemporaryFile(suffix='.db', delete=True) as tmp_file:
-        backup_path = tmp_file.name
+    status = {
+        'started_at': started_at.isoformat(),
+        'key': backup_key,
+        'success': False,
+        'phase': 'starting',
+    }
 
-        # Create safe backup using SQLite's online backup API
-        if not create_backup(db_path, backup_path):
+    # VACUUM INTO refuses to write to an existing file, so stage inside a private
+    # directory rather than using a pre-created NamedTemporaryFile.
+    work_dir = tempfile.mkdtemp(prefix='xratebot-backup-', dir=config['tmpdir'] or None)
+    snapshot_path = os.path.join(work_dir, 'snapshot.db')
+    upload_path = snapshot_path
+
+    if config['timeout'] > 0:
+        signal.alarm(config['timeout'])
+
+    try:
+        # Refuse to start rather than fill the disk the bot's own database lives on.
+        if not _has_room_to_stage(config['db_path'], work_dir, status):
             return False
 
-        # Upload to S3
-        if not upload_to_s3(backup_path, bucket, backup_key, s3_client):
+        phase_start = time.monotonic()
+        status['phase'] = 'snapshot'
+        if not create_snapshot(config['db_path'], snapshot_path, config['method'], config['drop_cache']):
             return False
+        snapshot_size = os.path.getsize(snapshot_path)
+        logger.info(
+            f"Snapshot created: {_human(snapshot_size)} in {time.monotonic() - phase_start:.1f}s "
+            f"({config['method']} method)"
+        )
+        status['snapshot_bytes'] = snapshot_size
+        status['snapshot_seconds'] = round(time.monotonic() - phase_start, 1)
 
-    # Cleanup old backups
-    cleanup_old_backups(bucket, prefix, retention, s3_client)
+        if config['compress']:
+            phase_start = time.monotonic()
+            status['phase'] = 'compress'
+            upload_path = f"{snapshot_path}.gz"
+            if not compress_file(snapshot_path, upload_path, config['compress_level'], config['drop_cache']):
+                return False
+            # Free the uncompressed copy immediately: on a small disk the two files
+            # together are the peak footprint of the whole cycle.
+            os.unlink(snapshot_path)
+            compressed_size = os.path.getsize(upload_path)
+            ratio = snapshot_size / compressed_size if compressed_size else 0
+            logger.info(
+                f"Snapshot compressed: {_human(compressed_size)} ({ratio:.1f}x) "
+                f"in {time.monotonic() - phase_start:.1f}s at level {config['compress_level']}"
+            )
+            status['compressed_bytes'] = compressed_size
+            status['compress_seconds'] = round(time.monotonic() - phase_start, 1)
 
-    logger.info(f"Backup cycle completed successfully: {backup_key}")
-    return True
+        phase_start = time.monotonic()
+        status['phase'] = 'upload'
+        if not upload_to_s3(
+            upload_path, config['s3_bucket'], backup_key, s3_client, transfer_config, config['extra_args']
+        ):
+            return False
+        upload_size = os.path.getsize(upload_path)
+        logger.info(
+            f"Upload finished: {_human(upload_size)} in {time.monotonic() - phase_start:.1f}s "
+            f"({_human(int(upload_size / max(time.monotonic() - phase_start, 0.001)))}/s)"
+        )
+        status['upload_seconds'] = round(time.monotonic() - phase_start, 1)
+
+        status['phase'] = 'cleanup'
+        cleanup_old_backups(config['s3_bucket'], config['s3_prefix'], config['retention'], s3_client)
+
+        status['phase'] = 'done'
+        status['success'] = True
+        logger.info(f"Backup cycle completed successfully: {backup_key} (peak RSS {_peak_rss()})")
+        return True
+
+    except BackupTimeout:
+        logger.error(f"Backup timed out after {config['timeout']}s during phase '{status['phase']}'")
+        status['error'] = f"timeout after {config['timeout']}s"
+        return False
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.error(f"Backup cycle failed during phase '{status['phase']}': {str(e)}")
+        status['error'] = str(e)
+        return False
+    finally:
+        if config['timeout'] > 0:
+            signal.alarm(0)
+        shutil.rmtree(work_dir, ignore_errors=True)
+        status['finished_at'] = datetime.now(timezone.utc).isoformat()
+        status['peak_rss'] = _peak_rss()
+        write_status(config['status_file'], status)
+
+
+def _handle_timeout(signum, frame):  # pylint: disable=unused-argument
+    """Convert SIGALRM into an exception so the cycle can clean up after itself."""
+    raise BackupTimeout()
+
+
+def _handle_termination(signum, frame):  # pylint: disable=unused-argument
+    """Exit cleanly on SIGTERM/SIGINT so `docker stop` does not look like a crash."""
+    logger.info(f"Received signal {signum}, shutting down")
+    sys.exit(0)
+
+
+def load_config() -> dict:
+    """
+    Resolve configuration from the environment.
+
+    Returns:
+        Dictionary with all resolved settings
+    """
+    s3_prefix = os.getenv('S3_PREFIX', 'backups/')
+    if s3_prefix and not s3_prefix.endswith('/'):
+        s3_prefix += '/'
+
+    config = {
+        'db_path': os.getenv('DB_PATH', 'data/exchange_rates.db'),
+        's3_endpoint_url': os.getenv('S3_ENDPOINT_URL'),
+        's3_bucket': os.getenv('S3_BUCKET'),
+        's3_prefix': s3_prefix,
+        's3_access_key': os.getenv('S3_ACCESS_KEY'),
+        's3_secret_key': os.getenv('S3_SECRET_KEY'),
+        's3_region': os.getenv('S3_REGION', 'us-east-1'),
+        's3_storage_class': os.getenv('S3_STORAGE_CLASS'),
+        'interval': _env_int('BACKUP_INTERVAL', 86400, minimum=60),
+        'retention': _env_int('BACKUP_RETENTION', 7, minimum=0),
+        'mode': os.getenv('BACKUP_MODE', 'scheduled'),
+        'tmpdir': os.getenv('BACKUP_TMPDIR', ''),
+        'method': os.getenv('BACKUP_METHOD', 'auto').strip().lower(),
+        'compress': _env_bool('BACKUP_COMPRESS', True),
+        'compress_level': _env_int('BACKUP_COMPRESS_LEVEL', 1, minimum=1, maximum=9),
+        'nice': _env_int('BACKUP_NICE', 19, minimum=0, maximum=19),
+        'ionice': _env_bool('BACKUP_IONICE', True),
+        'drop_cache': _env_bool('BACKUP_DROP_CACHE', True),
+        'timeout': _env_int('BACKUP_TIMEOUT', 3600, minimum=0),
+        'upload_concurrency': _env_int('BACKUP_UPLOAD_CONCURRENCY', 1, minimum=1, maximum=10),
+        'multipart_threshold': _env_int('BACKUP_MULTIPART_THRESHOLD', 64, minimum=5),
+        'multipart_chunksize': _env_int('BACKUP_MULTIPART_CHUNKSIZE', 16, minimum=5),
+        'status_file': os.getenv('BACKUP_STATUS_FILE', ''),
+        'log_file': os.getenv('BACKUP_LOG_FILE', ''),
+    }
+
+    if config['method'] not in ('auto', 'vacuum', 'copy'):
+        logger.warning(f"Unknown BACKUP_METHOD={config['method']!r}, falling back to 'auto'")
+        config['method'] = 'auto'
+
+    extra_args = {}
+    if config['s3_storage_class']:
+        extra_args['StorageClass'] = config['s3_storage_class']
+    if config['compress']:
+        extra_args['ContentType'] = 'application/gzip'
+    config['extra_args'] = extra_args or None
+
+    return config
 
 
 def main():
@@ -211,47 +725,75 @@ def main():
         logger.error("boto3 is not installed. Install it with: pip install boto3")
         sys.exit(1)
 
-    # Load configuration from environment
-    db_path = os.getenv('DB_PATH', 'data/exchange_rates.db')
-    s3_endpoint_url = os.getenv('S3_ENDPOINT_URL')
-    s3_bucket = os.getenv('S3_BUCKET')
-    s3_prefix = os.getenv('S3_PREFIX', 'backups/')
-    s3_access_key = os.getenv('S3_ACCESS_KEY')
-    s3_secret_key = os.getenv('S3_SECRET_KEY')
-    s3_region = os.getenv('S3_REGION', 'us-east-1')
-    backup_interval = int(os.getenv('BACKUP_INTERVAL', '86400'))
-    backup_retention = int(os.getenv('BACKUP_RETENTION', '7'))
-    backup_mode = os.getenv('BACKUP_MODE', 'scheduled')
-    log_level = os.getenv('LOG_LEVEL', 'INFO')
+    config = load_config()
 
     # Set logging level
-    logger.setLevel(log_level.upper())
+    logger.setLevel(os.getenv('LOG_LEVEL', 'INFO').upper())
+
+    # Mirror logs to a file on a mounted volume: when the host is loaded enough that
+    # ssh will not connect, this file is what explains the failure afterwards.
+    if config['log_file']:
+        try:
+            os.makedirs(os.path.dirname(config['log_file']) or '.', exist_ok=True)
+            file_handler = logging.FileHandler(config['log_file'])
+            file_handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
+            logger.addHandler(file_handler)
+        except OSError as e:
+            logger.warning(f"Could not open log file {config['log_file']}: {str(e)}")
 
     # Check if backup is enabled
-    if not os.getenv('BACKUP_ENABLED', 'false').lower() in ['true', '1', 'yes', 'on', 'enabled']:
+    if not _env_bool('BACKUP_ENABLED', False):
         logger.info("Backup is disabled. Set BACKUP_ENABLED=true to enable.")
         sys.exit(0)
 
-    # Ensure S3 prefix ends with /
-    if s3_prefix and not s3_prefix.endswith('/'):
-        s3_prefix += '/'
-
     # Validate required configuration
-    if not s3_bucket:
+    if not config['s3_bucket']:
         logger.error("S3_BUCKET is required")
         sys.exit(1)
-    if not s3_access_key:
+    if not config['s3_access_key']:
         logger.error("S3_ACCESS_KEY is required")
         sys.exit(1)
-    if not s3_secret_key:
+    if not config['s3_secret_key']:
         logger.error("S3_SECRET_KEY is required")
         sys.exit(1)
+    if config['tmpdir']:
+        try:
+            os.makedirs(config['tmpdir'], exist_ok=True)
+        except OSError as e:
+            logger.error(f"BACKUP_TMPDIR {config['tmpdir']} is not usable: {str(e)}")
+            sys.exit(1)
 
-    logger.info(f"Backup configuration: db_path={db_path}, bucket={s3_bucket}, prefix={s3_prefix}")
-    logger.info(f"Mode: {backup_mode}, interval: {backup_interval}s, retention: {backup_retention}")
+    signal.signal(signal.SIGTERM, _handle_termination)
+    signal.signal(signal.SIGINT, _handle_termination)
+    if config['timeout'] > 0:
+        signal.signal(signal.SIGALRM, _handle_timeout)
+
+    lower_process_priority(config['nice'], config['ionice'])
+
+    logger.info(
+        f"Backup configuration: db_path={config['db_path']}, bucket={config['s3_bucket']}, prefix={config['s3_prefix']}"
+    )
+    logger.info(f"Mode: {config['mode']}, interval: {config['interval']}s, retention: {config['retention']}")
+    logger.info(
+        f"Resources: staging={config['tmpdir'] or tempfile.gettempdir()}, method={config['method']}, "
+        f"compress={config['compress']}/level {config['compress_level']}, "
+        f"upload threads={config['upload_concurrency']}, chunk={config['multipart_chunksize']} MiB, "
+        f"nice={config['nice']}, ionice={config['ionice']}, timeout={config['timeout']}s"
+    )
 
     try:
-        s3_client = create_s3_client(s3_endpoint_url, s3_access_key, s3_secret_key, s3_region)
+        s3_client = create_s3_client(
+            config['s3_endpoint_url'],
+            config['s3_access_key'],
+            config['s3_secret_key'],
+            config['s3_region'],
+            config['upload_concurrency'],
+        )
+        transfer_config = create_transfer_config(
+            config['upload_concurrency'],
+            config['multipart_threshold'],
+            config['multipart_chunksize'],
+        )
     except NoCredentialsError:
         logger.error("Invalid S3 credentials")
         sys.exit(1)
@@ -259,21 +801,25 @@ def main():
         logger.error(f"Error creating S3 client: {str(e)}")
         sys.exit(1)
 
-    if backup_mode == 'once':
+    if config['mode'] == 'once':
         # One-shot mode: run single backup and exit
         logger.info("Starting one-shot backup")
-        success = run_backup(db_path, s3_client, s3_bucket, s3_prefix, backup_retention)
+        success = run_backup(config, s3_client, transfer_config)
         sys.exit(0 if success else 1)
     else:
         # Scheduled mode: run continuously
-        logger.info(f"Starting scheduled backup every {backup_interval} seconds")
+        logger.info(f"Starting scheduled backup every {config['interval']} seconds")
         while True:
-            success = run_backup(db_path, s3_client, s3_bucket, s3_prefix, backup_retention)
+            cycle_start = time.monotonic()
+            success = run_backup(config, s3_client, transfer_config)
+            # Subtract the time the cycle took so the schedule does not drift by the
+            # duration of every backup.
+            sleep_for = max(config['interval'] - (time.monotonic() - cycle_start), 60)
             if not success:
-                logger.error("Backup failed. Retrying in %d seconds...", backup_interval)
+                logger.error(f"Backup failed. Retrying in {sleep_for:.0f} seconds...")
             else:
-                logger.info(f"Backup compleated, next backup in {backup_interval} seconds")
-            time.sleep(backup_interval)
+                logger.info(f"Backup completed, next backup in {sleep_for:.0f} seconds")
+            time.sleep(sleep_for)
 
 
 if __name__ == "__main__":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,23 @@ services:
       - bot
     volumes:
       - ./data:/bot/data:ro
+      # Staging area for the snapshot. A named volume keeps the multi-hundred-megabyte
+      # temporary file on a real filesystem instead of the container layer, and keeps
+      # the status/log files readable after the container exits.
+      - backup-work:/backup/work
+    environment:
+      BACKUP_TMPDIR: /backup/work
+      BACKUP_STATUS_FILE: /backup/work/last_backup.json
+      BACKUP_LOG_FILE: /backup/work/backup.log
     env_file: .env.backup
     restart: unless-stopped
+    # Resource caps sized for a 512 MiB / 1 shared vCPU host: a backup can no longer
+    # take the whole box down with it. If it does not fit, it is OOM-killed inside its
+    # own cgroup while the bot and sshd keep running. Raise these on larger hosts.
+    cpus: 0.5
+    mem_limit: 192m
+    memswap_limit: 192m
+    pids_limit: 64
     profiles:
       - backup
   bot:
@@ -18,3 +33,5 @@ services:
       - ./data:/bot/data
     env_file: .env
     restart: unless-stopped
+volumes:
+  backup-work: {}


### PR DESCRIPTION
On a 512 MiB / single shared vCPU VM, backing up a ~0.5 GB database drove the load average into the double digits and frequently never reached the upload. Three causes, all addressed here:

- The snapshot was staged in the container layer and handed the kernel the whole database as dirty pages at once, stalling every process on the host (including sshd) in writeback.
- boto3 defaults to 10 concurrent 8 MiB parts, so the upload held ~80 MiB of buffers and ran TLS on ten threads, which is enough to be OOM-killed before anything is logged.
- The online backup API restarts the copy from scratch whenever the source is written mid-flight, so on a slow host it may never finish.

Changes to bot/backup.py:
- Snapshot with VACUUM INTO (BACKUP_METHOD), falling back to the online backup API. Smaller output, not restarted by concurrent writes.
- Stage the snapshot in BACKUP_TMPDIR on a mounted volume, and fsync plus posix_fadvise(DONTNEED) every 64 MiB so dirty pages stay bounded.
- Gzip the snapshot at level 1 before upload (BACKUP_COMPRESS).
- Bound the upload: single transfer thread, 16 MiB chunks, explicit timeouts and adaptive retries.
- Run at nice 19 in the idle I/O scheduling class.
- Delete expired backups in batches; BACKUP_RETENTION=0 delegates expiry to an S3 lifecycle rule. Add optional S3_STORAGE_CLASS.
- Add per-phase timings, a JSON status file, an optional log file, a hard timeout, a free-space pre-flight check, clean SIGTERM handling and drift-free scheduling.

Changes to docker-compose.yml:
- Cap the backup service at 0.5 CPU, 192 MiB and 64 PIDs so it can no longer take the host down with it.
- Add a backup-work volume for staging, status and log files.

Measured on a synthetic 79 MB WAL database: 49.7 MiB snapshot, 7.1 MiB uploaded (7.0x), 62 MB peak RSS.