### PR TITLE
Drop unused db indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Backup sidecar tuned for low-resource hosts:
 - Old backups are deleted in batches, or left to an S3 lifecycle rule with `BACKUP_RETENTION=0`
 - Added per-phase timings, a JSON status file, an optional log file, a hard timeout and clean `SIGTERM` handling
 
+Database size and small-host stability:
+- The five secondary indexes on `exchange_rates` are no longer created: the table is write-only in production, and measured with `dbstat` the indexes held roughly two thirds of the database file while making every insert update seven B-trees instead of two
+- New one-shot migration `bot/scripts/drop_unused_indexes.py` drops the old indexes on existing databases, compacts the file with `VACUUM` and activates `auto_vacuum=FULL` (a silent no-op on pre-existing databases until the next full vacuum)
+- The backup container now marks itself as the preferred host-OOM victim (`oom_score_adj: 500`) and the bot gets a 192 MiB leak-guard memory limit
+- New `docs/SMALL_HOST_RUNBOOK.md` walks through stabilising a 512 MiB droplet: adding swap, removing the maintenance jobs the OOM killer was cycling through (`fwupd`, `appstream`, `update-notifier`), and running the index migration
+
 ## v0.9.0
 
 [Added support of Turkish lira](https://github.com/yurnov/exchange-rate-telegram-bot/pull/46)

--- a/bot/database.py
+++ b/bot/database.py
@@ -213,16 +213,13 @@ class ExchangeRateDatabase:
                 )
             """)
 
-            # Create indexes for efficient queries
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_rates_timestamp ON exchange_rates(timestamp)")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_rates_api_timestamp ON exchange_rates(api_timestamp)")
-            cursor.execute(
-                "CREATE INDEX IF NOT EXISTS idx_rates_currency_pair ON exchange_rates(currency_code_a, currency_code_b, api_timestamp)"
-            )
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_rates_source ON exchange_rates(source, api_timestamp)")
-            cursor.execute(
-                "CREATE INDEX IF NOT EXISTS idx_rates_currency_a ON exchange_rates(currency_code_a, api_timestamp)"
-            )
+            # No secondary indexes on exchange_rates: the bot only ever inserts into
+            # this table (deduplication is served by the UNIQUE constraint's implicit
+            # index), while the five indexes previously created here were never read
+            # and accounted for roughly two thirds of the database file. Ad-hoc
+            # analysis queries can create the index they need on a copy of the data.
+            # Existing deployments: run bot/scripts/drop_unused_indexes.py once to
+            # remove the old indexes and shrink the file.
 
             self.conn.commit()
             logger.info("Database schema initialized successfully")

--- a/bot/scripts/drop_unused_indexes.py
+++ b/bot/scripts/drop_unused_indexes.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+One-shot migration: drop the unused exchange_rates indexes and compact the database.
+
+The exchange_rates table is write-only in production (the bot answers users from the
+live API and the chart builder reads the CSV), yet five secondary indexes were being
+maintained on it. Measured with dbstat, they held roughly two thirds of the file:
+every insert updated seven B-trees to serve queries that never ran, and every backup
+snapshotted and uploaded hundreds of megabytes of index pages.
+
+This script:
+1. Drops the five unused indexes (the UNIQUE constraint's implicit index, which
+   INSERT OR IGNORE deduplication relies on, is untouched).
+2. Runs VACUUM to rewrite the file without the freed pages. This is also what makes
+   the PRAGMA auto_vacuum=FULL setting take effect: on a database created before
+   that pragma was introduced it is a silent no-op until the next full VACUUM.
+3. Truncates the WAL so the shrunken state is in the main file.
+
+Stop the bot before running: VACUUM takes an exclusive lock and would stall or fail
+concurrent inserts. Expect the runtime of a full read+write of the database file
+(minutes on a small droplet). Free disk space of at least the current database size
+is required, which is checked before anything is dropped.
+
+Usage:
+    python drop_unused_indexes.py [path/to/exchange_rates.db]
+
+The script is intentionally standalone (standard library only), so it can run on the
+droplet's system python3 against the bind-mounted ./data directory, without starting
+any container.
+"""
+
+import ctypes
+import logging
+import os
+import platform
+import shutil
+import sqlite3
+import sys
+import time
+
+logging.basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+DEFAULT_DB_PATH = "data/exchange_rates.db"
+
+UNUSED_INDEXES = [
+    "idx_rates_timestamp",
+    "idx_rates_api_timestamp",
+    "idx_rates_currency_pair",
+    "idx_rates_source",
+    "idx_rates_currency_a",
+]
+
+# ioprio_set(2) syscall numbers, as in bot/backup.py. The script is standalone so it
+# can run on the host's python3, hence the small duplication instead of an import.
+IOPRIO_SET_SYSCALL = {'x86_64': 251, 'aarch64': 30, 'armv7l': 314, 'i686': 289}
+IOPRIO_WHO_PROCESS = 1
+IOPRIO_CLASS_BEST_EFFORT = 2
+IOPRIO_CLASS_SHIFT = 13
+IOPRIO_LOWEST_BEST_EFFORT = 7
+
+
+def lower_process_priority():
+    """Run at reduced CPU and I/O priority so the host stays responsive."""
+    try:
+        os.nice(10)
+    except OSError as e:
+        logger.warning(f"Could not lower CPU priority: {str(e)}")
+
+    syscall_number = IOPRIO_SET_SYSCALL.get(platform.machine())
+    if syscall_number is None:
+        return
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        priority = (IOPRIO_CLASS_BEST_EFFORT << IOPRIO_CLASS_SHIFT) | IOPRIO_LOWEST_BEST_EFFORT
+        libc.syscall(syscall_number, IOPRIO_WHO_PROCESS, 0, priority)
+    except (OSError, AttributeError):
+        pass
+
+
+def file_size(path: str) -> int:
+    """Return the size of a file, or 0 if it does not exist."""
+    try:
+        return os.path.getsize(path)
+    except OSError:
+        return 0
+
+
+def human(size: int) -> str:
+    """Format a byte count for logging."""
+    value = float(size)
+    for unit in ['B', 'KiB', 'MiB', 'GiB']:
+        if value < 1024 or unit == 'GiB':
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} GiB"
+
+
+def main() -> int:
+    """Drop unused indexes, VACUUM, and report the space reclaimed."""
+    db_path = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_DB_PATH
+    if not os.path.exists(db_path):
+        logger.error(f"Database not found: {db_path}")
+        return 1
+
+    before_db = file_size(db_path)
+    before_wal = file_size(f"{db_path}-wal")
+
+    # VACUUM rewrites the database into a temporary copy in the same directory, so
+    # it needs free space for a second (smaller) database plus some journal margin.
+    free = shutil.disk_usage(os.path.dirname(os.path.abspath(db_path))).free
+    if free < before_db:
+        logger.error(f"Not enough free disk space for VACUUM: {human(free)} free, {human(before_db)} needed")
+        return 1
+
+    lower_process_priority()
+
+    logger.info(f"Database: {db_path} ({human(before_db)} + {human(before_wal)} WAL)")
+
+    conn = sqlite3.connect(db_path, timeout=30)
+    try:
+        # Refuse to run while the bot holds the database, instead of stalling its
+        # inserts for the whole VACUUM.
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute("ROLLBACK")
+
+        existing = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='index'")}
+        for index in UNUSED_INDEXES:
+            if index in existing:
+                started = time.monotonic()
+                conn.execute(f"DROP INDEX {index}")
+                logger.info(f"Dropped {index} in {time.monotonic() - started:.1f}s")
+            else:
+                logger.info(f"Index {index} not present, skipping")
+        conn.commit()
+
+        # A no-op on databases already in FULL mode; on older files it is recorded
+        # here and materialised by the VACUUM below.
+        conn.execute("PRAGMA auto_vacuum=FULL")
+
+        logger.info("Running VACUUM (full rewrite of the database, this is the slow part)...")
+        started = time.monotonic()
+        conn.execute("VACUUM")
+        logger.info(f"VACUUM finished in {time.monotonic() - started:.1f}s")
+
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+
+        auto_vacuum = conn.execute("PRAGMA auto_vacuum").fetchone()[0]
+        remaining = [row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='index'")]
+    except sqlite3.OperationalError as e:
+        logger.error(f"Migration failed: {str(e)} (is the bot still running?)")
+        return 1
+    finally:
+        conn.close()
+
+    after_db = file_size(db_path)
+    after_wal = file_size(f"{db_path}-wal")
+    logger.info(f"Size before: {human(before_db)} (+{human(before_wal)} WAL)")
+    logger.info(f"Size after:  {human(after_db)} (+{human(after_wal)} WAL)")
+    logger.info(f"Reclaimed:   {human(max(before_db + before_wal - after_db - after_wal, 0))}")
+    logger.info(f"auto_vacuum={auto_vacuum} (1 means FULL is now active), remaining indexes: {remaining}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,10 @@ services:
     mem_limit: 320m
     memswap_limit: 320m
     pids_limit: 64
+    # If the *host* (not the cgroup) runs out of memory mid-backup, prefer killing
+    # the backup over the bot or sshd. A lost backup cycle retries; a lost bot drops
+    # user traffic.
+    oom_score_adj: 500
     profiles:
       - backup
   bot:
@@ -35,5 +39,9 @@ services:
       - ./data:/bot/data
     env_file: .env
     restart: unless-stopped
+    # Leak guard, not a working-set budget: the bot needs well under 100 MiB, so a
+    # runaway process hits its own cgroup limit (and restarts) instead of dragging
+    # the whole 512 MiB host into the OOM killer.
+    mem_limit: 192m
 volumes:
   backup-work: {}

--- a/docs/DATABASE_USAGE.md
+++ b/docs/DATABASE_USAGE.md
@@ -77,14 +77,29 @@ id | timestamp           | api_timestamp | source   | currency_code_a | currency
 
 ### Indexes
 
-The following indexes are created for efficient queries:
+The only index on `exchange_rates` is the implicit one backing the `UNIQUE(source,
+currency_code_a, currency_code_b, api_timestamp)` constraint, which serves the
+`INSERT OR IGNORE` deduplication.
+
+In production the table is write-only — the bot answers users from the live API and
+the chart builder reads the CSV — so no secondary indexes are maintained. Five were
+created historically (`idx_rates_timestamp`, `idx_rates_api_timestamp`,
+`idx_rates_currency_pair`, `idx_rates_source`, `idx_rates_currency_a`); measured
+with `dbstat` they held roughly two thirds of the database file and made every
+insert update seven B-trees instead of two. Existing databases can drop them and
+reclaim the space with a one-shot migration:
+
+```bash
+# Stop the bot first: the script refuses to run while the database is locked,
+# and the final VACUUM would block the bot's inserts anyway.
+python bot/scripts/drop_unused_indexes.py data/exchange_rates.db
+```
+
+For the ad-hoc analysis queries below, create the index you need on a **copy** of
+the database (e.g. a restored backup), where it costs the production host nothing:
 
 ```sql
-CREATE INDEX idx_rates_timestamp ON exchange_rates(timestamp);
-CREATE INDEX idx_rates_api_timestamp ON exchange_rates(api_timestamp);
 CREATE INDEX idx_rates_currency_pair ON exchange_rates(currency_code_a, currency_code_b, api_timestamp);
-CREATE INDEX idx_rates_source ON exchange_rates(source, api_timestamp);
-CREATE INDEX idx_rates_currency_a ON exchange_rates(currency_code_a, api_timestamp);
 ```
 
 ## Query Examples
@@ -505,7 +520,7 @@ conn.close()
 
 ## Performance Tips
 
-1. **Use indexes**: All common query patterns are already indexed
+1. **Use indexes**: Production carries no secondary indexes (see [Indexes](#indexes)); for analysis work, create the index your query needs on a copy of the database
 2. **Batch operations**: When inserting multiple rates, use transactions
 3. **Date filtering**: Use Unix timestamps for date comparisons (faster than datetime functions)
 4. **WAL mode**: Enabled by default for better concurrent read/write performance

--- a/docs/SMALL_HOST_RUNBOOK.md
+++ b/docs/SMALL_HOST_RUNBOOK.md
@@ -1,0 +1,172 @@
+# Runbook: stabilising a 512 MiB / 1 shared vCPU host
+
+Step-by-step instructions for the smallest DigitalOcean droplet (512 MiB RAM, one
+shared vCPU, no swap) running the bot, the backup sidecar and nothing else.
+
+## Symptoms this fixes
+
+`dmesg` shows the OOM killer firing every 30–60 minutes around the clock, killing
+`fwupd`, `appstreamcli`, `apt-get`, `apt-check` and `unattended-upgr` (and
+occasionally a `python`):
+
+```
+Out of memory: Killed process 563185 (appstreamcli) ... anon-rss:87192kB ...
+Out of memory: Killed process 563232 (apt-get)      ... anon-rss:87936kB ...
+Out of memory: Killed process 566341 (fwupd)        ... anon-rss:88832kB ...
+```
+
+Those are Ubuntu's automatic-maintenance jobs, each needing ~85–90 MiB. The kills
+are **not caused by the backup** (which runs once a day): the host sits at its
+memory ceiling at steady state, so every periodic job tips it over, dies, and is
+retried by its systemd timer — which also means security updates never complete.
+
+Separately, roughly **two thirds of the database file was secondary indexes that
+nothing reads** (the table is write-only in production), inflating every insert,
+checkpoint, snapshot and upload. This runbook removes them.
+
+Do the steps in order; each is independently useful.
+
+## Step 1 — Add swap (biggest single fix)
+
+DigitalOcean droplets ship without swap, so every memory spike is fatal instead of
+merely slow:
+
+```bash
+sudo fallocate -l 1G /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+
+# Prefer reclaiming page cache over swapping processes out
+echo 'vm.swappiness=10' | sudo tee /etc/sysctl.d/99-swap.conf
+sudo sysctl -p /etc/sysctl.d/99-swap.conf
+```
+
+Verify:
+
+```bash
+swapon --show   # should list /swapfile, 1G
+free -h         # Swap line no longer 0B
+```
+
+> DigitalOcean's docs discourage swap to spare SSD wear. On a 512 MiB droplet the
+> trade-off is clearly worth it: with `vm.swappiness=10` the swap is touched only
+> under real pressure, exactly when the alternative is the OOM killer.
+
+## Step 2 — Remove the maintenance jobs being killed anyway
+
+`fwupd` distributes firmware updates — pointless inside a VM. `appstream` and
+`update-notifier-common` refresh desktop-oriented package metadata:
+
+```bash
+sudo systemctl mask fwupd.service fwupd-refresh.timer
+sudo apt-get purge -y appstream update-notifier-common
+```
+
+**Keep `unattended-upgrades`** — it installs security patches. It was one of the
+processes dying, but with swap from Step 1 it can now finish its runs.
+
+Verify what still wakes up periodically:
+
+```bash
+systemctl list-timers --all
+```
+
+Expect `apt-daily.timer`, `apt-daily-upgrade.timer` and standard systemd timers;
+`fwupd-refresh.timer` should show as masked.
+
+## Step 3 — Take a backup before touching the database
+
+The migration in Step 4 rewrites the whole database file. Get a fresh backup first:
+
+```bash
+cd ~/exchange-rate/exchange-rate-telegram-bot
+docker compose run --rm -e BACKUP_MODE=once backup
+cat backup-work/last_backup.json   # expect "success": true, "phase": "done"
+```
+
+## Step 4 — Drop the unused indexes and compact the database
+
+This is a one-time migration (new databases are created without the indexes since
+this release). It roughly **halves the database file**, and with it the duration,
+CPU, disk and page-cache cost of every future backup. It also activates
+`auto_vacuum=FULL`, which `PRAGMA` alone silently does not do on a pre-existing
+database until the next full `VACUUM`.
+
+The bot must be stopped: the final `VACUUM` needs exclusive access (the script
+checks and refuses to run otherwise). Expect a few minutes of runtime on a slow
+disk and free disk space of at least the current database size (also checked).
+
+```bash
+cd ~/exchange-rate/exchange-rate-telegram-bot
+
+# 1. Pull images containing this change, so the bot does not recreate the indexes
+docker compose pull
+
+# 2. Stop the bot
+docker compose stop bot
+
+# 3. Run the migration with the droplet's own python3 against the mounted data dir
+python3 bot/scripts/drop_unused_indexes.py data/exchange_rates.db
+
+# 4. Start the bot again
+docker compose up -d bot
+```
+
+The script logs sizes before/after and the space reclaimed, and finishes with
+`auto_vacuum=1`. The only index left on `exchange_rates` is the implicit UNIQUE
+one that deduplication relies on.
+
+If the repository is not checked out on the droplet, fetch just the script:
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/yurnov/exchange-rate-telegram-bot/main/bot/scripts/drop_unused_indexes.py
+python3 drop_unused_indexes.py data/exchange_rates.db
+```
+
+## Step 5 — Deploy the compose changes
+
+This release adds two lines to `docker-compose.yml`; if you maintain a locally
+modified compose file on the droplet, port them over:
+
+- `oom_score_adj: 500` on the **backup** service — if the *host* runs out of memory
+  mid-backup, the kernel kills the backup (which retries next cycle) rather than
+  the bot or sshd. The in-cgroup limits (`mem_limit: 320m`) are unchanged.
+- `mem_limit: 192m` on the **bot** service — a leak guard, not a working-set
+  budget: the bot needs well under 100 MiB, so a runaway process restarts inside
+  its own cgroup instead of dragging the whole host down.
+
+Then:
+
+```bash
+docker compose up -d
+```
+
+## Step 6 — Verify
+
+```bash
+# No new OOM kills accumulating (give it a few hours / a day)
+sudo dmesg -T | grep -i 'killed process' | tail
+
+# Memory now has headroom and swap absorbs spikes
+free -h
+
+# Database roughly halved, WAL small
+ls -lh data/exchange_rates.db*
+
+# Next scheduled backup: snapshot time and uploaded size should drop ~50%
+cat backup-work/last_backup.json
+```
+
+## Rollback
+
+Every step is reversible:
+
+- Swap: `sudo swapoff /swapfile && sudo rm /swapfile`, remove the `/etc/fstab` line.
+- Services: `sudo systemctl unmask fwupd.service fwupd-refresh.timer`,
+  `sudo apt-get install appstream update-notifier-common`.
+- Indexes: recreate any of them at the cost of one full table scan, e.g.
+  `CREATE INDEX idx_rates_timestamp ON exchange_rates(timestamp);` — the schema
+  in [DATABASE_USAGE.md](DATABASE_USAGE.md) lists the original five definitions.
+- Compose: revert the two added lines.


### PR DESCRIPTION
This pull request focuses on significantly improving the stability and resource usage of the bot and backup system on low-memory hosts, especially 512 MiB droplets. The main changes are the removal of unused database indexes (which drastically reduces database size and resource consumption), the addition of a migration script to clean up existing databases, and Docker/container tweaks to better handle out-of-memory (OOM) scenarios. Documentation has been expanded to provide a detailed runbook for deploying these improvements on small hosts.

**Database schema and migration:**
* Removed all five secondary indexes from the `exchange_rates` table in `bot/database.py`, as they were never read in production and accounted for about two thirds of the database file size. Only the implicit index for the UNIQUE constraint remains.
* Added a new one-shot migration script `bot/scripts/drop_unused_indexes.py` that drops the old indexes, compacts the database with `VACUUM`, and enables `auto_vacuum=FULL` for existing deployments. The script is safe, standalone, and logs reclaimed space.

**Container resource management:**
* The backup container now sets `oom_score_adj: 500` so the host OOM killer will prefer terminating the backup over the bot or sshd if the host runs out of memory.
* The bot container now has a `mem_limit: 192m` as a leak guard, ensuring runaway processes are contained without affecting the entire host.
